### PR TITLE
#2 - Create XML parser for JaCoCo reports

### DIFF
--- a/jacoco_filter/model.py
+++ b/jacoco_filter/model.py
@@ -1,0 +1,47 @@
+# jacoco_filter/model.py
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+@dataclass
+class Counter:
+    type: str
+    missed: int
+    covered: int
+    xml_element: Any
+
+    @classmethod
+    def from_xml(cls, elem):
+        return cls(
+            type=elem.get("type"),
+            missed=int(elem.get("missed")),
+            covered=int(elem.get("covered")),
+            xml_element=elem,
+        )
+
+@dataclass
+class Method:
+    name: str
+    desc: str
+    line: Optional[str]
+    counters: list[Counter] = field(default_factory=list)
+    xml_element: Any = None
+
+@dataclass
+class Class:
+    name: str
+    methods: list[Method] = field(default_factory=list)
+    counters: list[Counter] = field(default_factory=list)
+    xml_element: Any = None
+
+@dataclass
+class Package:
+    name: str
+    classes: list[Class] = field(default_factory=list)
+    counters: list[Counter] = field(default_factory=list)
+    xml_element: Any = None
+
+@dataclass
+class JacocoReport:
+    packages: list[Package] = field(default_factory=list)
+    xml_element: Any = None

--- a/jacoco_filter/parser.py
+++ b/jacoco_filter/parser.py
@@ -1,0 +1,47 @@
+# jacoco_filter/parser.py
+
+from lxml import etree
+from pathlib import Path
+from jacoco_filter.model import JacocoReport, Package, Class, Method, Counter
+
+
+class JacocoParser:
+    def __init__(self, xml_path: Path):
+        self.xml_path = xml_path
+
+    def parse(self) -> JacocoReport:
+        tree = etree.parse(str(self.xml_path))
+        root = tree.getroot()
+
+        report = JacocoReport(xml_element=root)
+
+        for pkg_elem in root.findall("package"):
+            pkg = Package(xml_element=pkg_elem, name=pkg_elem.get("name"))
+            report.packages.append(pkg)
+
+            for cls_elem in pkg_elem.findall("class"):
+                cls = Class(xml_element=cls_elem, name=cls_elem.get("name"))
+                pkg.classes.append(cls)
+
+                for meth_elem in cls_elem.findall("method"):
+                    meth = Method(
+                        xml_element=meth_elem,
+                        name=meth_elem.get("name"),
+                        desc=meth_elem.get("desc"),
+                        line=meth_elem.get("line")
+                    )
+                    cls.methods.append(meth)
+
+                    for counter_elem in meth_elem.findall("counter"):
+                        counter = Counter.from_xml(counter_elem)
+                        meth.counters.append(counter)
+
+                for counter_elem in cls_elem.findall("counter"):
+                    counter = Counter.from_xml(counter_elem)
+                    cls.counters.append(counter)
+
+            for counter_elem in pkg_elem.findall("counter"):
+                counter = Counter.from_xml(counter_elem)
+                pkg.counters.append(counter)
+
+        return report

--- a/main.py
+++ b/main.py
@@ -1,4 +1,7 @@
+from pathlib import Path
+
 from jacoco_filter.cli import parse_arguments
+from jacoco_filter.parser import JacocoParser
 
 if __name__ == "__main__":
     args = parse_arguments()
@@ -6,4 +9,10 @@ if __name__ == "__main__":
     print(f"  input:  {args.input}")
     print(f"  rules:  {args.rules}")
     print(f"  output: {args.output}")
+
+    parser = JacocoParser(xml_path=args.input)
+    report = parser.parse()
+
+    print(f"Found {len(report.packages)} packages")
+
 


### PR DESCRIPTION
- Added JacocoParser in parser.py to parse jacoco.xml files using lxml
- Constructs a hierarchical in-memory model with packages, classes, methods, and counters
- Includes dataclass-based definitions in model.py with preserved links to original XML elements

Closes #2 