### PR TITLE
#5 - Implement filter engine to apply rules

### DIFF
--- a/examples/sample.xml
+++ b/examples/sample.xml
@@ -12,6 +12,17 @@
             <counter type="INSTRUCTION" missed="7" covered="18"/>
             <counter type="LINE" missed="1" covered="3"/>
         </class>
+        <class name="com/example/AnotherClass" sourcefilename="AnotherClass.java">
+            <method name="doWork" desc="()V" line="10">
+                <counter type="INSTRUCTION" missed="5" covered="10"/>
+                <counter type="LINE" missed="1" covered="3"/>
+            </method>
+            <method name="getData" desc="()Ljava/lang/String;" line="20">
+                <counter type="INSTRUCTION" missed="2" covered="8"/>
+            </method>
+            <counter type="INSTRUCTION" missed="7" covered="18"/>
+            <counter type="LINE" missed="1" covered="3"/>
+        </class>
         <counter type="INSTRUCTION" missed="7" covered="18"/>
     </package>
 </report>

--- a/jacoco_filter/filter_engine.py
+++ b/jacoco_filter/filter_engine.py
@@ -1,0 +1,46 @@
+# jacoco_filter/filter_engine.py
+
+from fnmatch import fnmatchcase
+from jacoco_filter.model import JacocoReport, Package, Class, Method
+from jacoco_filter.rules import FilterRule
+
+
+class FilterEngine:
+    def __init__(self, rules: list[FilterRule]):
+        self.rules = rules
+        self.stats = {
+            "methods_removed": 0,
+            "classes_removed": 0
+        }
+
+    def apply(self, report: JacocoReport):
+        for package in report.packages:
+            remaining_classes = []
+
+            for cls in package.classes:
+                if self._matches(cls.name, "class"):
+                    print(f"[DEBUG] Removing class: {cls.name}")
+                    self.stats["classes_removed"] += 1
+                    continue  # Skip entire class and its methods
+
+                remaining_methods = []
+                for method in cls.methods:
+                    if self._matches(method.name, "method"):
+                        print(f"[DEBUG] Removing method: {method.name} in class {cls.name}")
+                        self.stats["methods_removed"] += 1
+                        continue  # Skip matched method
+                    remaining_methods.append(method)
+
+                cls.methods = remaining_methods
+                remaining_classes.append(cls)
+
+            package.classes = remaining_classes
+
+    def _matches(self, name: str, scope: str) -> bool:
+        for rule in self.rules:
+            if rule.scope == scope:
+                match = fnmatchcase(name, rule.pattern)
+                print(f"[DEBUG] Matching {scope} '{name}' against '{rule.pattern}' => {match}")
+                if match:
+                    return True
+        return False

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from jacoco_filter.cli import parse_arguments
+from jacoco_filter.filter_engine import FilterEngine
 from jacoco_filter.parser import JacocoParser
 from jacoco_filter.rules import load_filter_rules
 
@@ -22,3 +23,9 @@ if __name__ == "__main__":
     print(f"✅ Loaded {len(rules)} rule(s):")
     for rule in rules:
         print(f"   - {rule.scope}:{rule.pattern}")
+
+    # Apply filtering
+    engine = FilterEngine(rules)
+    engine.apply(report)
+
+    print(f"✅ Filter applied: {engine.stats['classes_removed']} class(es) and {engine.stats['methods_removed']} method(s) removed.")


### PR DESCRIPTION
- Adds FilterEngine class to traverse JacocoReport and apply filter rules
- Supports both class and method scopes with wildcard matching via fnmatchcase
- Skips method-level filtering inside already removed classes to prevent double-counting
- Tracks statistics for removed classes and methods
- Includes debug output to trace rule matching behavior

Closes #5 