### PR TITLE
#7 - Implement report serializer

### DIFF
--- a/jacoco_filter/filter_engine.py
+++ b/jacoco_filter/filter_engine.py
@@ -21,14 +21,23 @@ class FilterEngine:
                 if self._matches(cls.name, "class"):
                     print(f"[DEBUG] Removing class: {cls.name}")
                     self.stats["classes_removed"] += 1
-                    continue  # Skip entire class and its methods
+                    # Remove XML element
+                    parent_elem = cls.xml_element.getparent()
+                    if parent_elem is not None:
+                        parent_elem.remove(cls.xml_element)
+                    continue
 
                 remaining_methods = []
                 for method in cls.methods:
                     if self._matches(method.name, "method"):
                         print(f"[DEBUG] Removing method: {method.name} in class {cls.name}")
                         self.stats["methods_removed"] += 1
-                        continue  # Skip matched method
+                        # Remove XML element
+                        if cls.xml_element is not None:
+                            method_elem = method.xml_element
+                            if method_elem is not None:
+                                cls.xml_element.remove(method_elem)
+                        continue
                     remaining_methods.append(method)
 
                 cls.methods = remaining_methods

--- a/jacoco_filter/serializer.py
+++ b/jacoco_filter/serializer.py
@@ -1,0 +1,19 @@
+# jacoco_filter/serializer.py
+
+from pathlib import Path
+from lxml import etree
+from jacoco_filter.model import JacocoReport
+
+
+class ReportSerializer:
+    def __init__(self, report: JacocoReport):
+        self.report = report
+
+    def write_to_file(self, output_path: Path):
+        tree = etree.ElementTree(self.report.xml_element)
+        tree.write(
+            str(output_path),
+            encoding="utf-8",
+            pretty_print=True,
+            xml_declaration=True
+        )

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from jacoco_filter.counter_updater import CounterUpdater
 from jacoco_filter.filter_engine import FilterEngine
 from jacoco_filter.parser import JacocoParser
 from jacoco_filter.rules import load_filter_rules
+from jacoco_filter.serializer import ReportSerializer
 
 if __name__ == "__main__":
     # Parse CLI arguments
@@ -40,3 +41,8 @@ if __name__ == "__main__":
                 print(f"[DEBUG] Class '{cls.name}' counter {counter.type}: missed={counter.missed}, covered={counter.covered}")
 
     print("✅ Counters updated successfully.")
+
+    serializer = ReportSerializer(report)
+    serializer.write_to_file(args.output)
+
+    print(f"✅ Filtered report saved to: {args.output}")


### PR DESCRIPTION
- Uses original XML root node modified in-place
- Writes XML to specified output path with utf-8 encoding and pretty-print formatting
- Ensures compatibility with JaCoCo tools by preserving structure and schema

Closes #7 