### PR TITLE
#10 - Create PyInstaller configuration for binary packaging

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# build.sh
+
+set -e
+
+# Ensure we're in the project root
+cd "$(dirname "$0")"
+
+echo "🔧 Activating virtual environment..."
+source .venv/bin/activate
+
+echo "🔨 Building jacoco-filter using PyInstaller..."
+pyinstaller jacoco_filter.spec
+
+echo "✅ Done. Binary located at: dist/jacoco-filter"

--- a/jacoco_filter/main.py
+++ b/jacoco_filter/main.py
@@ -14,7 +14,10 @@ from jacoco_filter.serializer import ReportSerializer
 
 def main():
     try:
+        print("✅ jacoco-filter started")
+
         args = parse_arguments()
+        print(f"Args: {args}")
 
         print("📥 Loading report...")
         parser = JacocoParser(args.input)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+altgraph==0.17.4
+macholib==1.16.3
+packaging==25.0
+pyinstaller==6.14.1
+pyinstaller-hooks-contrib==2025.5
+setuptools==80.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+lxml>=4.9.3
+pyinstaller>=6.4

--- a/run_filter.py
+++ b/run_filter.py
@@ -1,0 +1,4 @@
+from jacoco_filter.main import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Added jacoco_filter.spec to define PyInstaller bundling configuration
- Manually included lxml C extensions for macOS compatibility
- Created build.sh script to automate packaging from virtualenv
- Verified that the resulting binary works standalone without Python
- CLI flow tested end-to-end with input XML, rules, and output file

This completes support for building a single-file executable for macOS.

Closes #10 