### PR TITLE
#21 - Enhanced Glob Pattern Support for Filtering Rules in jacoco-filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,44 +4,10 @@ A command-line tool to filter [JaCoCo](https://www.jacoco.org/jacoco/) XML cover
 
 ---
 
-## 🚀 Features (v1.0.0 - Pilot)
-
-- CLI interface for passing input/output files and filter rules
-- Parses `jacoco.xml` into memory
-- Filters classes or methods based on rules
-- Resets coverage counters appropriately
-- Serializes the modified report back to XML
-- Packaged as a single executable via PyInstaller
-
----
-
 ## 🧪 Example usage
 
 ```bash
 python3 main.py --input examples/sample.xml --rules examples/rules.txt --output output.xml
-```
-
-## Rule Format
-
-Each rule defines a class or method to be **excluded from coverage**.  
-Rules are written in the format:
-
-```text
-<scope>:<pattern>
-```
-
-### Supported scopes:
-- `class` — fully-qualified class name (e.g. `com/example/MyClass`)
-- `method` — method name only (e.g. `get*`)
-
-### Wildcards:
-- `*` allowed only at the beginning or end of the pattern
-- Example: `method:get*` filters out any method starting with `get`
-
-### Example rules.txt:
-```text
-class:com/example/MyClass
-method:get*
 ```
 
 ## Requirements
@@ -49,3 +15,51 @@ method:get*
 - Python 3.12+
 - lxml (for XML parsing)
 - pytest (for testing)
+
+## Rule Format
+
+Each rule defines a class, file, or method to be excluded from coverage. Rules are written in the format:
+
+```text
+<scope>:<pattern>
+```
+
+### Supported scopes:
+
+- `file` — source file name (e.g. `*Test.scala`, `Helper*.java`)
+- `class` — fully-qualified class name (dot-separated, e.g. `com.example.MyClass`)
+- `method` — method name only or scoped as Class#method (e.g. `get*`, `MyClass#handle*`)
+
+### Wildcards:
+
+- Supported via `fnmatchcase()` (shell-style)
+- Available characters:
+  - `*` — any sequence of characters
+  - `?` — any single character
+  - `[seq]` — any character in sequence
+- Matching is **case-sensitive**
+
+### Valid Rule Examples
+
+#### File
+```text
+file:*.scala               # All Scala source files
+file:*Test*                # Any file containing "Test" in the name
+file:SpecHelper.scala      # Exact match
+```
+
+#### Class
+```text
+class:com.example.*        # All classes in the package and subpackages
+class:*.TestClass          # Any class ending in TestClass
+class:com.*.util.*Helper   # All Helper classes under any util package
+class:MainApp              # Simple class match
+```
+
+#### Method
+```text
+method:get*                              # Any method starting with get
+method:UserController#get*               # Scoped to a specific class
+method:com.example.*Service#handle*      # Class and method patterns matched together using fully-qualified class name
+method:Foo#toString                      # Specific method in class Foo
+```

--- a/examples/rules.txt
+++ b/examples/rules.txt
@@ -1,10 +1,20 @@
-# Filter out this class entirely
-class:com/example/MyClass
+# Rules for excluding elements from JaCoCo report
+# Syntax: <scope>:<pattern>
+# Use wildcards (*, ?, [seq]) as per fnmatchcase rules (case-sensitive)
+# Lines starting with '#' are ignored as comments
 
-# Filter out any method starting with 'get'
-method:get*
+# --- File Rules ---
+file:*Spec.scala                                    # All Scala test specs
+file:HelperUtil.scala                               # Helper utilities
+file:AnotherClass.java                              # Specific Java class file
 
-# Invalid examples (should trigger errors if uncommented)
-# class
-# method:
-# invalidline
+# --- Class Rules ---
+class:com.example.MyClass                           # Exact class match
+class:com.extra.example.*                                 # All classes in the com.extra.example package
+class:com.example.util.*Helper                      # All helper classes under util
+
+# --- Method Rules ---
+method:get*                                         # Match all getter-style methods globally
+method:AnotherClass#get*                            # Match all getters in AnotherClass
+method:com.example.util.MyHelper#getInternalState   # Target a specific method with FQCN
+method:TestSpec#test*                               # Match all test* methods in TestSpec

--- a/examples/sample.xml
+++ b/examples/sample.xml
@@ -1,35 +1,43 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <report name="Test Report">
-    <package name="com/example">
-        <class name="com/example/MyClass" sourcefilename="MyClass.java">
-            <method name="doWork" desc="()V" line="10">
-                <counter type="INSTRUCTION" missed="5" covered="10"/>
-                <counter type="LINE" missed="1" covered="3"/>
-                <counter type="BRANCH" missed="1" covered="1"/>
-                <counter type="METHOD" missed="0" covered="1"/>
-            </method>
-            <method name="getData" desc="()Ljava/lang/String;" line="20">
-                <counter type="INSTRUCTION" missed="2" covered="8"/>
-                <counter type="COMPLEXITY" missed="1" covered="0"/>
-            </method>
-            <counter type="INSTRUCTION" missed="7" covered="18"/>
-            <counter type="LINE" missed="1" covered="3"/>
-            <counter type="CLASS" missed="0" covered="1"/>
-        </class>
-        <class name="com/example/AnotherClass" sourcefilename="AnotherClass.java">
-            <method name="doWork" desc="()V" line="10">
-                <counter type="INSTRUCTION" missed="3" covered="7"/>
-                <counter type="LINE" missed="0" covered="4"/>
-                <counter type="BRANCH" missed="2" covered="2"/>
-            </method>
-            <method name="getData" desc="()Ljava/lang/String;" line="20">
-                <counter type="INSTRUCTION" missed="1" covered="4"/>
-                <counter type="METHOD" missed="1" covered="0"/>
-            </method>
-            <counter type="INSTRUCTION" missed="4" covered="11"/>
-            <counter type="LINE" missed="0" covered="4"/>
-        </class>
-        <counter type="INSTRUCTION" missed="11" covered="29"/>
-        <counter type="COMPLEXITY" missed="2" covered="1"/>
+
+    <package name="pkg/file_rule">
+        <class name="pkg/file_rule/AnotherClass" sourcefilename="AnotherClass.java">
+            <method name="doWork" desc="()V" line="10"><counter type="INSTRUCTION" missed="0" covered="10"/><counter type="LINE" missed="0" covered="5"/><counter type="METHOD" missed="0" covered="1"/></method>
+            <counter type="INSTRUCTION" missed="0" covered="10"/><counter type="LINE" missed="0" covered="5"/><counter type="METHOD" missed="0" covered="1"/></class>
+        <class name="pkg/file_rule/HelperUtil" sourcefilename="HelperUtil.scala">
+            <method name="assist" desc="()V" line="15"><counter type="INSTRUCTION" missed="0" covered="10"/><counter type="LINE" missed="0" covered="5"/><counter type="METHOD" missed="0" covered="1"/></method>
+            <counter type="INSTRUCTION" missed="0" covered="10"/><counter type="LINE" missed="0" covered="5"/><counter type="METHOD" missed="0" covered="1"/></class>
+        <class name="pkg/file_rule/TestSpec" sourcefilename="TestSpec.scala">
+            <method name="testAll" desc="()V" line="5"><counter type="INSTRUCTION" missed="0" covered="10"/><counter type="LINE" missed="0" covered="5"/><counter type="METHOD" missed="0" covered="1"/></method>
+            <counter type="INSTRUCTION" missed="0" covered="10"/><counter type="LINE" missed="0" covered="5"/><counter type="METHOD" missed="0" covered="1"/></class>
     </package>
-</report>
+
+    <package name="pkg/class_rule">
+        <class name="com/example/MyClass" sourcefilename="MyClass.java">
+            <method name="doWork" desc="()V" line="5"><counter type="INSTRUCTION" missed="0" covered="10"/><counter type="LINE" missed="0" covered="5"/><counter type="METHOD" missed="0" covered="1"/></method>
+            <counter type="INSTRUCTION" missed="0" covered="10"/><counter type="LINE" missed="0" covered="5"/><counter type="METHOD" missed="0" covered="1"/></class>
+        <class name="com/extra/example/ExtraClass" sourcefilename="ExtraClass.java">
+            <method name="extraMethod" desc="()V" line="10"><counter type="INSTRUCTION" missed="0" covered="10"/><counter type="LINE" missed="0" covered="5"/><counter type="METHOD" missed="0" covered="1"/></method>
+            <counter type="INSTRUCTION" missed="0" covered="10"/><counter type="LINE" missed="0" covered="5"/><counter type="METHOD" missed="0" covered="1"/></class>
+        <class name="com/example/util/DataHelper" sourcefilename="DataHelper.java">
+            <method name="assist" desc="()V" line="12"><counter type="INSTRUCTION" missed="0" covered="10"/><counter type="LINE" missed="0" covered="5"/><counter type="METHOD" missed="0" covered="1"/></method>
+            <counter type="INSTRUCTION" missed="0" covered="10"/><counter type="LINE" missed="0" covered="5"/><counter type="METHOD" missed="0" covered="1"/></class>
+    </package>
+
+    <package name="pkg/method_rule">
+        <class name="com/example/util/MyHelper" sourcefilename="HelperUtil.scala">
+            <method name="getInternalState" desc="()V" line="8"><counter type="INSTRUCTION" missed="0" covered="10"/><counter type="LINE" missed="0" covered="5"/><counter type="METHOD" missed="0" covered="1"/></method>
+            <counter type="INSTRUCTION" missed="0" covered="10"/><counter type="LINE" missed="0" covered="5"/><counter type="METHOD" missed="0" covered="1"/></class>
+        <class name="com/example/TestSpec" sourcefilename="TestSpec.scala">
+            <method name="testSomething" desc="()V" line="6"><counter type="INSTRUCTION" missed="0" covered="10"/><counter type="LINE" missed="0" covered="5"/><counter type="METHOD" missed="0" covered="1"/></method>
+            <counter type="INSTRUCTION" missed="0" covered="10"/><counter type="LINE" missed="0" covered="5"/><counter type="METHOD" missed="0" covered="1"/></class>
+        <class name="com/example/AnotherClass" sourcefilename="AnotherClass.java">
+            <method name="getName" desc="()Ljava/lang/String;" line="12"><counter type="INSTRUCTION" missed="0" covered="10"/><counter type="LINE" missed="0" covered="5"/><counter type="METHOD" missed="0" covered="1"/></method>
+            <counter type="INSTRUCTION" missed="0" covered="10"/><counter type="LINE" missed="0" covered="5"/><counter type="METHOD" missed="0" covered="1"/></class>
+        <class name="pkg/method_rule/GlobalGetter" sourcefilename="Generic.java">
+            <method name="getData" desc="()Ljava/lang/String;" line="20"><counter type="INSTRUCTION" missed="0" covered="10"/><counter type="LINE" missed="0" covered="5"/><counter type="METHOD" missed="0" covered="1"/></method>
+            <counter type="INSTRUCTION" missed="0" covered="10"/><counter type="LINE" missed="0" covered="5"/><counter type="METHOD" missed="0" covered="1"/></class>
+    </package>
+
+    <counter type="INSTRUCTION" missed="0" covered="100"/><counter type="LINE" missed="0" covered="50"/><counter type="METHOD" missed="0" covered="10"/></report>

--- a/jacoco_filter/rules.py
+++ b/jacoco_filter/rules.py
@@ -1,41 +1,115 @@
 # jacoco_filter/rules.py
-
-from dataclasses import dataclass
+import re
+from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
 from fnmatch import fnmatchcase
+from typing import Optional
 
+
+class ScopeEnum(str, Enum):
+    FILE = "file"
+    CLASS = "class"
+    METHOD = "method"
+
+    @classmethod
+    def has_value(cls, value: str) -> bool:
+        return value in cls._value2member_map_
 
 @dataclass
 class FilterRule:
-    scope: str  # "class" or "method"
+    scope: ScopeEnum  # "file", "class", or "method"
     pattern: str
+    target_class_pattern: Optional[str] = field(init=False, default=None)
+    target_method_pattern: Optional[str] = field(init=False, default=None)
 
-    def matches(self, target: str) -> bool:
-        return fnmatchcase(target, self.pattern)
+    def __post_init__(self):
+        if self.scope == ScopeEnum.METHOD:
+            if "#" in self.pattern:
+                self.target_class_pattern, self.target_method_pattern = self.pattern.split("#", 1)
+            else:
+                self.target_class_pattern = None
+                self.target_method_pattern = self.pattern
 
+    def matches(self, target: dict) -> bool:
+        try:
+            match self.scope:
+                case ScopeEnum.FILE:
+                    return fnmatchcase(target["sourcefilename"], self.pattern)
+
+                case ScopeEnum.CLASS:
+                    return fnmatchcase(target["fully_qualified_classname"], self.pattern)
+
+                case ScopeEnum.METHOD:
+                    method_name = target["method_name"]
+                    fqcn = target.get("fully_qualified_classname", "")
+                    simple_class = target.get("simple_class_name", fqcn.split(".")[-1] if fqcn else "")
+
+                    print(f"[DEBUG] METHOD: fqcn={fqcn}, simple_class={simple_class}, method={method_name}")
+                    print(f"[DEBUG] Rule: class_pattern={self.target_class_pattern}, method_pattern={self.target_method_pattern}")
+
+                    if self.target_class_pattern:
+                        class_match = (
+                            fnmatchcase(fqcn, self.target_class_pattern)
+                            or fnmatchcase(simple_class, self.target_class_pattern)
+                        )
+
+                        if not class_match:
+                            print(f"[DEBUG] Rule '{self.pattern}' did not match class '{fqcn}' or '{simple_class}'")
+                            return False
+
+                    matched = fnmatchcase(method_name, self.target_method_pattern)
+                    print(f"[DEBUG] Matching method '{method_name}' with rule '{self.pattern}' => {matched}")
+                    return matched
+
+                case _:
+                    return False
+
+        except KeyError as e:
+            raise KeyError(f"Missing key '{e.args[0]}' in target dict for rule: {self.scope}:{self.pattern}")
 
 def load_filter_rules(path: Path) -> list[FilterRule]:
     rules = []
 
     with path.open("r", encoding="utf-8") as f:
-        for lineno, line in enumerate(f, start=1):
-            line = line.strip()
-            if not line or line.startswith("#"):
+        for lineno, raw_line in enumerate(f, start=1):
+            # tady tohle zda se spatne odstrani koment u get* - over, kde vsude se neodstrani?
+            line = strip_comment(raw_line.strip())
+            if not line:
                 continue
 
             if ":" not in line:
                 raise ValueError(f"Invalid rule format on line {lineno}: '{line}'")
 
+            if line.count(":") > 1:
+                raise ValueError(f"Multiple colons found on line {lineno}: '{line}'")
+
             scope, pattern = line.split(":", 1)
             scope = scope.strip().lower()
             pattern = pattern.strip()
 
-            if scope not in {"class", "method"}:
-                raise ValueError(f"Unsupported rule scope on line {lineno}: '{scope}'")
+            if not ScopeEnum.has_value(scope):
+                raise ValueError(f"Unsupported rule scope '{scope}' on line {line}")
 
             if not pattern:
                 raise ValueError(f"Empty pattern on line {lineno}")
 
-            rules.append(FilterRule(scope=scope, pattern=pattern))
+            rules.append(FilterRule(scope=ScopeEnum(scope), pattern=pattern))
 
     return rules
+
+def strip_comment(line: str) -> str:
+    """
+    Strips trailing comments from a rule line, preserving '#' used in method patterns.
+    A '#' is considered a comment only if it is preceded by a space.
+    """
+    line = line.strip()
+    if not line or line.startswith("#"):
+        return ""
+
+    # This regex matches the rule, preserving # inside patterns (e.g. MyClass#get*)
+    # and removes the comment if there's a space before the # (e.g. '  # comment')
+    comment_match = re.search(r"(.*?)\s+#.*$", line)
+    if comment_match:
+        return comment_match.group(1).strip()
+    return line

--- a/notes.txt
+++ b/notes.txt
@@ -1,0 +1,5 @@
+python3 run_filter.py --input examples/sample.xml --rules examples/rules.txt --output output.xml
+
+python3 -m jacoco_filter --input examples/sample.xml --rules examples/rules.txt --output output.xml
+
+./dist/jacoco-filter/jacoco-filter --input examples/sample.xml --rules examples/rules.txt --output output.xml


### PR DESCRIPTION
- Fully supports fnmatchcase patterns for file:, class:, and method: scopes
- Normalizes class names (slashes → dots) for matching
- Improves strip_comment() to preserve # in method patterns like MyClass#get*
- Enables smart comment stripping only when # is preceded by whitespace

Closes #21 